### PR TITLE
feat: local-file editing workflow, fidelity warnings, and bug fixes

### DIFF
--- a/dist/markdown-transformer/docsToMarkdown.js
+++ b/dist/markdown-transformer/docsToMarkdown.js
@@ -4,6 +4,65 @@
  * When these are detected on a text run, we render backtick code in markdown.
  */
 const CODE_FONT_FAMILIES = new Set(['Roboto Mono', 'Courier New', 'Consolas', 'monospace']);
+/**
+ * Inspects a Google Docs JSON structure for content that docsJsonToMarkdown
+ * cannot represent. Returns an array of human-readable warning strings (empty
+ * if the document converts losslessly). Call before replaceDocumentWithMarkdown
+ * to give the AI a heads-up about what will be permanently lost.
+ *
+ * Checked: images, headers/footers, footnotes, custom text/highlight colors,
+ * non-default paragraph alignment (CENTER, RIGHT, JUSTIFIED).
+ */
+export function checkMarkdownFidelity(docData) {
+    const warnings = [];
+    // Images
+    const imageCount = docData.inlineObjects ? Object.keys(docData.inlineObjects).length : 0;
+    if (imageCount > 0) {
+        warnings.push(`${imageCount} image(s) — will be removed`);
+    }
+    // Headers / footers
+    if (docData.headers && Object.keys(docData.headers).length > 0) {
+        warnings.push('Document headers — will be removed');
+    }
+    if (docData.footers && Object.keys(docData.footers).length > 0) {
+        warnings.push('Document footers — will be removed');
+    }
+    // Footnotes
+    const footnoteCount = docData.footnotes ? Object.keys(docData.footnotes).length : 0;
+    if (footnoteCount > 0) {
+        warnings.push(`${footnoteCount} footnote(s) — will be removed`);
+    }
+    // Scan body paragraphs for custom colors and non-default alignment
+    let hasCustomColors = false;
+    let hasNonDefaultAlignment = false;
+    const content = docData.body?.content ?? [];
+    for (const element of content) {
+        if (!element.paragraph) continue;
+        const alignment = element.paragraph.paragraphStyle?.alignment;
+        if (alignment && alignment !== 'START' && alignment !== 'UNSPECIFIED') {
+            hasNonDefaultAlignment = true;
+        }
+        for (const pe of (element.paragraph.elements ?? [])) {
+            const style = pe.textRun?.textStyle;
+            if (!style) continue;
+            const fgRgb = style.foregroundColor?.color?.rgbColor;
+            if (fgRgb && ((fgRgb.red ?? 0) > 0 || (fgRgb.green ?? 0) > 0 || (fgRgb.blue ?? 0) > 0)) {
+                hasCustomColors = true;
+            }
+            const bgRgb = style.backgroundColor?.color?.rgbColor;
+            if (bgRgb && ((bgRgb.red ?? 0) > 0 || (bgRgb.green ?? 0) > 0 || (bgRgb.blue ?? 0) > 0)) {
+                hasCustomColors = true;
+            }
+        }
+    }
+    if (hasCustomColors) {
+        warnings.push('Custom text/highlight colors — will be lost');
+    }
+    if (hasNonDefaultAlignment) {
+        warnings.push('Non-default paragraph alignment (center/right/justified) — will be lost');
+    }
+    return warnings;
+}
 // --- Main Conversion ---
 /**
  * Converts Google Docs JSON structure to a markdown string.

--- a/dist/markdown-transformer/docsToMarkdown.js
+++ b/dist/markdown-transformer/docsToMarkdown.js
@@ -13,7 +13,7 @@ const CODE_FONT_FAMILIES = new Set(['Roboto Mono', 'Courier New', 'Consolas', 'm
  * Checked: images, headers/footers, footnotes, custom text/highlight colors,
  * non-default paragraph alignment (CENTER, RIGHT, JUSTIFIED).
  */
-export function checkMarkdownFidelity(docData) {
+export function checkMarkdownFidelity(docData, scanContent = null) {
     const warnings = [];
     // Images
     const imageCount = docData.inlineObjects ? Object.keys(docData.inlineObjects).length : 0;
@@ -32,17 +32,12 @@ export function checkMarkdownFidelity(docData) {
     if (footnoteCount > 0) {
         warnings.push(`${footnoteCount} footnote(s) — will be removed`);
     }
-    // Scan body paragraphs for custom colors and non-default alignment
+    // Scan for custom colors and non-default alignment.
+    // scanContent overrides the body to scan (used in tab mode to target the active tab).
     let hasCustomColors = false;
     let hasNonDefaultAlignment = false;
-    const content = docData.body?.content ?? [];
-    for (const element of content) {
-        if (!element.paragraph) continue;
-        const alignment = element.paragraph.paragraphStyle?.alignment;
-        if (alignment && alignment !== 'START' && alignment !== 'UNSPECIFIED') {
-            hasNonDefaultAlignment = true;
-        }
-        for (const pe of (element.paragraph.elements ?? [])) {
+    function scanParagraphElements(elements) {
+        for (const pe of elements) {
             const style = pe.textRun?.textStyle;
             if (!style) continue;
             const fgRgb = style.foregroundColor?.color?.rgbColor;
@@ -55,6 +50,24 @@ export function checkMarkdownFidelity(docData) {
             }
         }
     }
+    function scanBodyContent(bodyContent) {
+        for (const element of bodyContent) {
+            if (element.paragraph) {
+                const alignment = element.paragraph.paragraphStyle?.alignment;
+                if (alignment && alignment !== 'START' && alignment !== 'UNSPECIFIED') {
+                    hasNonDefaultAlignment = true;
+                }
+                scanParagraphElements(element.paragraph.elements ?? []);
+            } else if (element.table) {
+                for (const row of (element.table.tableRows ?? [])) {
+                    for (const cell of (row.tableCells ?? [])) {
+                        scanBodyContent(cell.content ?? []);
+                    }
+                }
+            }
+        }
+    }
+    scanBodyContent(scanContent ?? docData.body?.content ?? []);
     if (hasCustomColors) {
         warnings.push('Custom text/highlight colors — will be lost');
     }

--- a/dist/markdown-transformer/index.js
+++ b/dist/markdown-transformer/index.js
@@ -12,7 +12,7 @@
 import { docsJsonToMarkdown } from './docsToMarkdown.js';
 import { convertMarkdownToRequests } from './markdownToDocs.js';
 import { executeBatchUpdateWithSplitting, findTabById } from '../googleDocsApiHelpers.js';
-export { docsJsonToMarkdown } from './docsToMarkdown.js';
+export { docsJsonToMarkdown, checkMarkdownFidelity } from './docsToMarkdown.js';
 /** Formats InsertMarkdownResult into a concise human-readable debug summary. */
 export function formatInsertResult(result) {
     const lines = [];

--- a/dist/tools/docs/readGoogleDoc.js
+++ b/dist/tools/docs/readGoogleDoc.js
@@ -4,7 +4,7 @@ import { createPatch } from 'diff';
 import { getDocsClient, getDriveClient } from '../../clients.js';
 import { DocumentIdParameter, NotImplementedError } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
-import { docsJsonToMarkdown } from '../../markdown-transformer/index.js';
+import { docsJsonToMarkdown, checkMarkdownFidelity } from '../../markdown-transformer/index.js';
 import { trackRead, getLastReadContent } from '../../readTracker.js';
 
 async function fetchModifiedTime(documentId) {
@@ -95,6 +95,10 @@ export function register(server) {
                     const markdownContent = docsJsonToMarkdown(contentSource);
                     const totalLength = markdownContent.length;
                     log.info(`Generated markdown: ${totalLength} characters`);
+                    // Run fidelity check on the full doc JSON (not the tab-scoped subset)
+                    // so we catch headers/footers/footnotes/inlineObjects stored at doc root.
+                    const fidelitySource = args.tabId ? res.data : contentSource;
+                    const fidelityWarnings = checkMarkdownFidelity(fidelitySource);
                     if (args.diffFromLastRead) {
                         const previous = getLastReadContent(args.documentId);
                         if (previous !== null) {
@@ -111,13 +115,24 @@ export function register(server) {
                         }
                         log.info('diffFromLastRead requested but no prior snapshot exists; returning full content');
                     }
+                    // Store clean markdown (without warning) for future diffs and guardMutation
                     trackRead(args.documentId, modifiedTime, markdownContent);
                     // Apply length limit to markdown if specified
+                    let output;
                     if (args.maxLength && totalLength > args.maxLength) {
                         const truncatedContent = markdownContent.substring(0, args.maxLength);
-                        return `${truncatedContent}\n\n... [Markdown truncated to ${args.maxLength} chars of ${totalLength} total. Use maxLength parameter to adjust limit or remove it to get full content.]`;
+                        output = `${truncatedContent}\n\n... [Markdown truncated to ${args.maxLength} chars of ${totalLength} total. Use maxLength parameter to adjust limit or remove it to get full content.]`;
+                    } else {
+                        output = markdownContent;
                     }
-                    return markdownContent;
+                    // Append fidelity warning after the markdown so the AI knows what
+                    // replaceDocumentWithMarkdown would permanently destroy.
+                    if (fidelityWarnings.length > 0) {
+                        output += '\n\n---\n⚠️ FORMATTING LOSS WARNING: This document contains content that cannot be represented in markdown. Calling replaceDocumentWithMarkdown will permanently lose:\n' +
+                            fidelityWarnings.map(w => `  • ${w}`).join('\n') +
+                            '\nConsider using modifyText or appendMarkdown for targeted edits instead.\n---';
+                    }
+                    return output;
                 }
                 // Default: Text format - extract all text content
                 if (args.diffFromLastRead) {

--- a/dist/tools/docs/readGoogleDoc.js
+++ b/dist/tools/docs/readGoogleDoc.js
@@ -1,3 +1,6 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { createPatch } from 'diff';
@@ -6,6 +9,10 @@ import { DocumentIdParameter, NotImplementedError } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { docsJsonToMarkdown, checkMarkdownFidelity } from '../../markdown-transformer/index.js';
 import { trackRead, getLastReadContent } from '../../readTracker.js';
+
+function getWorkspacePath(documentId) {
+    return path.join(os.tmpdir(), 'google-tools-mcp', `${documentId}.md`);
+}
 
 async function fetchModifiedTime(documentId) {
     try {
@@ -24,7 +31,11 @@ async function fetchModifiedTime(documentId) {
 export function register(server) {
     server.addTool({
         name: 'readDocument',
-        description: "Reads the content of a Google Document. Returns markdown by default (formatted content suitable for editing and re-uploading with replaceDocumentWithMarkdown). Use format='text' for plain text, or format='json' for the raw document structure. Set diffFromLastRead=true (markdown only) to get a unified diff from your previous read in this session instead of the full content.",
+        description: "Reads the content of a Google Document. Returns markdown by default and saves it to a local file (path included in response). " +
+            "PREFERRED EDITING WORKFLOW: (1) readDocument to get the local file path, (2) edit that file locally, (3) call replaceDocumentWithMarkdown with filePath pointing to it. " +
+            "This avoids inline content truncation and gives you a reviewable working copy before pushing changes. " +
+            "Use format='text' for plain text, or format='json' for the raw document structure. " +
+            "Set diffFromLastRead=true (markdown only) to get a unified diff from your previous read instead of the full content.",
         parameters: DocumentIdParameter.extend({
             format: z
                 .enum(['text', 'json', 'markdown'])
@@ -71,7 +82,7 @@ export function register(server) {
                     if (!targetTab.documentTab) {
                         throw new UserError(`Tab "${args.tabId}" does not have content (may not be a document tab).`);
                     }
-                    contentSource = { body: targetTab.documentTab.body };
+                    contentSource = { body: targetTab.documentTab.body, lists: targetTab.documentTab.lists };
                     log.info(`Using content from tab: ${targetTab.tabProperties?.title || 'Untitled'}`);
                 }
                 else {
@@ -95,10 +106,12 @@ export function register(server) {
                     const markdownContent = docsJsonToMarkdown(contentSource);
                     const totalLength = markdownContent.length;
                     log.info(`Generated markdown: ${totalLength} characters`);
-                    // Run fidelity check on the full doc JSON (not the tab-scoped subset)
-                    // so we catch headers/footers/footnotes/inlineObjects stored at doc root.
-                    const fidelitySource = args.tabId ? res.data : contentSource;
-                    const fidelityWarnings = checkMarkdownFidelity(fidelitySource);
+                    // Doc-level metadata (images/headers/footers/footnotes) always from res.data.
+                    // Color/alignment scan targets the active tab's body when tabId is set.
+                    const fidelityBodyContent = args.tabId
+                        ? GDocsHelpers.findTabById(res.data, args.tabId)?.documentTab?.body?.content ?? null
+                        : null;
+                    const fidelityWarnings = checkMarkdownFidelity(res.data, fidelityBodyContent);
                     if (args.diffFromLastRead) {
                         const previous = getLastReadContent(args.documentId);
                         if (previous !== null) {
@@ -111,12 +124,31 @@ export function register(server) {
                                 { context: 3 }
                             );
                             trackRead(args.documentId, modifiedTime, markdownContent);
+                            // Update workspace file so it stays in sync even on diff reads
+                            try {
+                                const wp = getWorkspacePath(args.documentId);
+                                await fs.mkdir(path.dirname(wp), { recursive: true });
+                                await fs.writeFile(wp, markdownContent, 'utf-8');
+                            } catch (e) {
+                                log.info(`Could not update workspace on diff read: ${e.message}`);
+                            }
                             return patch;
                         }
                         log.info('diffFromLastRead requested but no prior snapshot exists; returning full content');
                     }
                     // Store clean markdown (without warning) for future diffs and guardMutation
                     trackRead(args.documentId, modifiedTime, markdownContent);
+                    // Save to local workspace file so the AI can edit it and push with filePath
+                    let localPath = null;
+                    try {
+                        localPath = getWorkspacePath(args.documentId);
+                        await fs.mkdir(path.dirname(localPath), { recursive: true });
+                        await fs.writeFile(localPath, markdownContent, 'utf-8');
+                        log.info(`Saved to ${localPath}`);
+                    } catch (e) {
+                        log.info(`Could not save to workspace: ${e.message}`);
+                        localPath = null;
+                    }
                     // Apply length limit to markdown if specified
                     let output;
                     if (args.maxLength && totalLength > args.maxLength) {
@@ -131,6 +163,12 @@ export function register(server) {
                         output += '\n\n---\n⚠️ FORMATTING LOSS WARNING: This document contains content that cannot be represented in markdown. Calling replaceDocumentWithMarkdown will permanently lose:\n' +
                             fidelityWarnings.map(w => `  • ${w}`).join('\n') +
                             '\nConsider using modifyText or appendMarkdown for targeted edits instead.\n---';
+                    }
+                    if (localPath) {
+                        // Use forward slashes in the advice string so the path is valid JSON
+                        // regardless of OS (backslashes in Windows paths break JSON encoding).
+                        const jsonSafePath = localPath.replace(/\\/g, '/');
+                        output += `\n\n📄 Local file: ${localPath}\nEdit this file, then call replaceDocumentWithMarkdown with filePath="${jsonSafePath}" to push changes.`;
                     }
                     return output;
                 }

--- a/dist/tools/utils/replaceDocumentWithMarkdown.js
+++ b/dist/tools/utils/replaceDocumentWithMarkdown.js
@@ -1,4 +1,6 @@
 import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getDocsClient } from '../../clients.js';
@@ -6,17 +8,23 @@ import { DocumentIdParameter, MarkdownConversionError } from '../../types.js';
 import * as GDocsHelpers from '../../googleDocsApiHelpers.js';
 import { insertMarkdown, formatInsertResult, docsJsonToMarkdown } from '../../markdown-transformer/index.js';
 import { guardMutation, trackMutation } from '../../readTracker.js';
+
+function getWorkspacePath(documentId) {
+    return path.join(os.tmpdir(), 'google-tools-mcp', `${documentId}.md`);
+}
 export function register(server) {
     server.addTool({
         name: 'replaceDocumentWithMarkdown',
         description: "Best for rewriting entire sections or full documents. Replaces the entire document body with content parsed from markdown. " +
             "Supports headings, bold, italic, strikethrough, links, and bullet/numbered lists. " +
-            "Use readDocument with format='markdown' first to get the current content, edit it, then call this tool to apply changes. " +
+            "PREFERRED WORKFLOW: (1) call readDocument first — it saves the content to a local temp file and returns the path, " +
+            "(2) edit that file locally with your changes, (3) call this tool with filePath pointing to it. " +
+            "Prefer filePath over the inline markdown parameter — it avoids content truncation and lets you review edits before pushing. " +
             "For small single-location edits (one line or paragraph), use modifyText instead. " +
             "To add content without rewriting, use appendMarkdown.",
         parameters: DocumentIdParameter.extend({
-            markdown: z.string().optional().describe('The markdown content to apply to the document. For content longer than ~2000 characters, prefer writing to a local file first and passing filePath instead.'),
-            filePath: z.string().optional().describe('Path to a local markdown file to use as content. Takes precedence over the markdown parameter. Use this for large documents to avoid truncation.'),
+            markdown: z.string().optional().describe('Inline markdown content. Prefer filePath instead — use this only for short content under ~2000 characters where writing a file first is impractical.'),
+            filePath: z.string().optional().describe('Path to a local markdown file. PREFERRED over inline markdown — use the path returned by readDocument, edit that file, then pass it here.'),
             preserveTitle: z
                 .boolean()
                 .optional()
@@ -52,6 +60,18 @@ export function register(server) {
             }
             if (!markdown || markdown.length === 0) {
                 throw new UserError('Either markdown or filePath must be provided with non-empty content.');
+            }
+            // When inline markdown is given (not filePath), persist it to the temp workspace so
+            // there is always a local copy of what was pushed.
+            if (!args.filePath && markdown) {
+                try {
+                    const workspacePath = getWorkspacePath(args.documentId);
+                    await fs.mkdir(path.dirname(workspacePath), { recursive: true });
+                    await fs.writeFile(workspacePath, markdown, 'utf-8');
+                    log.info(`Saved working copy to ${workspacePath}`);
+                } catch (e) {
+                    log.info(`Could not save working copy: ${e.message}`);
+                }
             }
             log.info(`Replacing doc ${args.documentId} with markdown (${markdown.length} chars)${args.tabId ? ` in tab ${args.tabId}` : ''}`);
             try {


### PR DESCRIPTION
## Problem

When an AI reads a Google Doc with `readDocument` (format=`markdown`) and then calls `replaceDocumentWithMarkdown`, two things go wrong:

1. **Silent formatting loss** — images, headers/footers, footnotes, custom colors, and non-default alignment are permanently destroyed with no warning.
2. **Inline content truncation** — large docs passed as inline `markdown=` strings get cut off mid-content by the MCP protocol.

## What changed

### Local-file editing workflow (`readDocument` + `replaceDocumentWithMarkdown`)

`readDocument` now auto-saves the markdown to a temp file (`os.tmpdir()/google-tools-mcp/{documentId}.md`) and appends the path to its response with instructions to edit locally and push via `filePath=`. This avoids inline truncation and gives the AI a reviewable working copy before pushing.

`replaceDocumentWithMarkdown` descriptions updated to strongly prefer `filePath` over inline `markdown=`. When inline markdown is used, it's also saved to the same temp path for consistency.

### Fidelity loss warnings

Adds `checkMarkdownFidelity(docData)` to `docsToMarkdown.js` that inspects raw document JSON for content `docsJsonToMarkdown` cannot represent. `readDocument` calls it and appends a ⚠️ warning block when lossy content is detected.

The clean markdown (without the warning) is stored in `trackRead`, so `guardMutation` diffs and `diffFromLastRead` are unaffected.

**What's checked:**

| Content | Why it's lossy |
|---|---|
| Images (`inlineObjects`) | Dropped entirely — no markdown equivalent |
| Document headers/footers | Not part of body content, never written back |
| Footnotes | No markdown footnote support in the writer |
| Custom text/highlight colors | `docsJsonToMarkdown` ignores color styling |
| Non-default alignment (center/right/justified) | Paragraph style not emitted as markdown |

### Bug fixes (follow-up commit)

- **Fidelity check now recurses into table cells** — previously missed all color/alignment formatting inside tables
- **Tab-mode fidelity check now scans the correct body** — when `tabId` is set, color/alignment scan targets the active tab's body; doc-level metadata (images/headers/footers) still checked at root
- **Tab-mode list rendering fixed** — `readDocument` was passing `{ body }` without `lists` to `docsJsonToMarkdown`, breaking list nesting/ordering in tabbed docs
- **`diffFromLastRead` now updates the workspace file** — the on-disk `.md` file was staying at the old snapshot after a diff read, so subsequent edits would be based on stale content
- **Windows path backslashes fixed** — the `filePath="..."` advice string now uses forward slashes so the path is valid JSON on Windows (backslash + U/A are illegal JSON escape sequences)

## Example warning output

```
---
⚠️ FORMATTING LOSS WARNING: This document contains content that cannot be represented in markdown. Calling replaceDocumentWithMarkdown will permanently lose:
  • 3 image(s) — will be removed
  • Document headers — will be removed
  • Custom text/highlight colors — will be lost
Consider using modifyText or appendMarkdown for targeted edits instead.
---
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)