### PR TITLE
fix: match emulated horizontal rule color to Google's native line

### DIFF
--- a/dist/markdown-transformer/markdownToDocs.js
+++ b/dist/markdown-transformer/markdownToDocs.js
@@ -1051,7 +1051,18 @@ function finalizeFormatting(context) {
             },
         });
     }
-    // Horizontal rule styling (bottom border on empty paragraphs)
+    // Horizontal rule styling (bottom border on empty paragraphs).
+    //
+    // The Google Docs REST API cannot insert a true native horizontal rule
+    // (the `horizontalRule` ParagraphElement produced by Insert > Horizontal
+    // line); that remains an open API limitation
+    // (https://issuetracker.google.com/issues/152996327). A bottom border on
+    // an empty paragraph is the closest achievable emulation.
+    //
+    // Color/weight are matched to Google's native rule, which renders at
+    // #878787 (rgb 135/255) and 1pt thick — measured by rasterizing a PDF
+    // export of a doc containing native rules. The previous value (0.75 grey,
+    // #bfbfbf) rendered noticeably lighter than the real thing.
     for (const hrRange of context.hrRanges) {
         const range = {
             startIndex: hrRange.startIndex,
@@ -1066,7 +1077,7 @@ function finalizeFormatting(context) {
                 paragraphStyle: {
                     borderBottom: {
                         color: {
-                            color: { rgbColor: { red: 0.75, green: 0.75, blue: 0.75 } },
+                            color: { rgbColor: { red: 0.5294117647, green: 0.5294117647, blue: 0.5294117647 } },
                         },
                         width: { magnitude: 1, unit: 'PT' },
                         padding: { magnitude: 6, unit: 'PT' },


### PR DESCRIPTION
### Problem

Markdown `---` renders as a noticeably light, "washed-out" line that doesn't match Google's native **Insert → Horizontal line**. Because the Docs REST API can't insert a true `horizontalRule` element ([issuetracker #152996327](https://issuetracker.google.com/issues/152996327)), the rule is emulated with a bottom border on an empty paragraph — but the border color was `0.75` grey (`#bfbfbf`), which is much lighter than the real thing.

### Fix

Set the border color to `#878787` (rgb `135/255` → `0.5294`), which is Google's actual native rule color. I measured it by rasterizing a PDF export of a doc containing native rules (native = `#878787`, 1pt; the old emulation = `#bfbfbf`). Width (1pt) already matched, so this is a color-only change.

### Notes

Still a bordered-paragraph emulation, not the literal native element (REST API limitation), but it's now color-accurate. Minimal change in `finalizeFormatting`; the blockquote left-border (the other `0.75`) is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
