### PR TITLE
feat: optional shared HTTP transport (GOOGLE_MCP_TRANSPORT=http) — one server for many clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,12 +293,47 @@ Google Forms — create/read forms, manage responses, and publish settings.
 | `GOOGLE_CLIENT_ID` | No* | OAuth 2.0 Client ID |
 | `GOOGLE_CLIENT_SECRET` | No* | OAuth 2.0 Client Secret |
 | `GOOGLE_MCP_PROFILE` | No | Profile name for multi-account support (see above) |
+| `GOOGLE_MCP_TRANSPORT` | No | `stdio` (default) or `http`. Use `http` to run one shared server (see [Shared HTTP mode](#shared-http-mode-one-server-for-many-clients)) |
+| `GOOGLE_MCP_PORT` | No | Port for HTTP transport (default `3939`) |
+| `GOOGLE_MCP_ENDPOINT` | No | URL path for HTTP transport (default `/mcp`) |
 | `LOG_LEVEL` | No | `debug`, `info`, `warn`, `error`, or `silent` |
 | `GOOGLE_MCP_LOG_FILE` | No | Set to `1` to log to `~/.config/google-tools-mcp/server.log`, or set to a custom file path |
 | `SERVICE_ACCOUNT_PATH` | No | Path to service account JSON key (alternative to OAuth) |
 | `GOOGLE_IMPERSONATE_USER` | No | Email to impersonate with service account |
 
 \* Not required as env vars if you provide credentials via `.env` file or `credentials.json` (see [Step 2](#step-2-provide-your-credentials)).
+
+## Shared HTTP mode (one server for many clients)
+
+By default the server uses **stdio** transport: each MCP client spawns its own
+`google-tools-mcp` process. If you run several clients at once (e.g. many editor
+or agent sessions), that's one Node process per session, each holding memory.
+
+Set `GOOGLE_MCP_TRANSPORT=http` to instead run a **single long-lived server**
+that every client shares over a localhost URL — one process regardless of how
+many clients connect:
+
+```bash
+# start one shared server (keep it running; e.g. a login item or service)
+GOOGLE_MCP_TRANSPORT=http GOOGLE_MCP_PORT=3939 google-tools-mcp
+```
+
+Then point each client at the URL instead of a spawn command:
+
+```json
+{
+  "mcpServers": {
+    "google": { "type": "http", "url": "http://localhost:3939/mcp" }
+  }
+}
+```
+
+Notes:
+- The shared server does **not** start or stop with your clients — you manage
+  its lifecycle (start it at login / run it as a service).
+- All clients share one OAuth/token state and one process. FastMCP's HTTP-stream
+  transport tracks a separate session per client, so concurrent use is fine.
+- Auth (`google-tools-mcp auth` / `setup`) is unchanged and still uses stdio.
 
 ## Migrating from gdrive-tools-mcp / gmail-tools-mcp
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -37,6 +37,16 @@ if (process.argv[2] === 'auth') {
     }
 }
 
+// --- Transport selection ---
+// Default is stdio (one server spawned per MCP client, the classic model).
+// Set GOOGLE_MCP_TRANSPORT=http to run a single long-lived HTTP server that
+// many clients share over a localhost URL — one process instead of one per
+// session. Accepts "http" or "httpStream" (both map to FastMCP httpStream).
+const transportEnv = (process.env.GOOGLE_MCP_TRANSPORT || 'stdio').toLowerCase();
+const useHttp = transportEnv === 'http' || transportEnv === 'httpstream';
+const httpPort = Number(process.env.GOOGLE_MCP_PORT) || 3939;
+const httpEndpoint = process.env.GOOGLE_MCP_ENDPOINT || '/mcp';
+
 // --- Process lifecycle logging ---
 process.on('uncaughtException', (error) => {
     logger.error('Uncaught Exception:', error);
@@ -55,14 +65,20 @@ process.on('SIGTERM', () => {
 // Exit when the MCP client closes the stdio pipe.
 // This is the primary shutdown path for stdio MCP servers — SIGTERM is not
 // reliably delivered on Windows when a parent process exits.
-process.stdin.on('close', () => {
-    logger.info('stdin closed — MCP client disconnected. Shutting down.');
-    process.exit(0);
-});
-process.stdin.on('end', () => {
-    logger.info('stdin ended — MCP client disconnected. Shutting down.');
-    process.exit(0);
-});
+//
+// IMPORTANT: only wire these in stdio mode. In HTTP mode the server is a
+// detached daemon whose stdin ends/closes immediately at launch — attaching
+// these there would make the daemon exit the instant it starts.
+if (!useHttp) {
+    process.stdin.on('close', () => {
+        logger.info('stdin closed — MCP client disconnected. Shutting down.');
+        process.exit(0);
+    });
+    process.stdin.on('end', () => {
+        logger.info('stdin ended — MCP client disconnected. Shutting down.');
+        process.exit(0);
+    });
+}
 process.on('exit', (code) => {
     logger.info(`Process exiting with code ${code}.`);
 });
@@ -77,8 +93,17 @@ await registerAllTools(server);
 
 try {
     logger.info('Starting google-tools-mcp server...');
-    await server.start({ transportType: 'stdio' });
-    logger.info('MCP Server running using stdio. Awaiting client connection...');
+    if (useHttp) {
+        await server.start({
+            transportType: 'httpStream',
+            httpStream: { port: httpPort, endpoint: httpEndpoint },
+        });
+        logger.info(`MCP Server running over HTTP at http://localhost:${httpPort}${httpEndpoint}`);
+        logger.info('Shared mode: point every client at this URL instead of spawning per-session stdio servers.');
+    } else {
+        await server.start({ transportType: 'stdio' });
+        logger.info('MCP Server running using stdio. Awaiting client connection...');
+    }
     logger.info('Google auth will run automatically on first tool call.');
 } catch (startError) {
     logger.error('FATAL: Server failed to start:', startError.message || startError);


### PR DESCRIPTION
## Summary

Adds an **opt-in HTTP transport** so a single `google-tools-mcp` process can serve many MCP clients at once, instead of one process per client. Behavior is unchanged unless you set `GOOGLE_MCP_TRANSPORT=http` — **stdio remains the default and the diff is fully backward compatible.**

---

## Background: why one process per client happens today

MCP defines two main transports:

- **stdio** — the client launches the server as a child process and talks to it over that child's stdin/stdout. This is a strict **1:1** relationship: the pipe *is* the connection, so there is one server process per client process, by design.
- **HTTP (streamable)** — the server is a standalone process listening on a URL; clients connect over the network. This is **1:many** — many clients share one server, each getting its own logical session.

This server only ever starts in stdio mode:

```js
// dist/index.js (before)
await server.start({ transportType: 'stdio' });
```

So if you run several MCP clients simultaneously (multiple editor windows, multiple agent sessions, a few terminals), each one spawns its **own** full `google-tools-mcp` Node process. With 10 sessions that's ~10 Node processes — each loads all 11 tool categories and holds its own memory footprint — with no built-in way to consolidate them. stdio has no cross-client pooling; that's not a bug in this server, it's inherent to the transport.

For anyone running many concurrent sessions, that's real, idle RAM multiplied by session count, plus a process-startup cost on every new session.

## What this PR changes

Transport is now selectable at startup via environment variables. **Default is `stdio`** — existing setups are untouched.

| Variable | Default | Effect |
|---|---|---|
| `GOOGLE_MCP_TRANSPORT` | `stdio` | Set to `http` (or `httpStream`) to run one shared HTTP server |
| `GOOGLE_MCP_PORT` | `3939` | Port for HTTP transport |
| `GOOGLE_MCP_ENDPOINT` | `/mcp` | URL path for HTTP transport |

Implementation uses FastMCP's built-in `httpStream` transport — **already a dependency** (FastMCP 3.35.x), no new packages. FastMCP tracks a distinct session per connecting client (via the `Mcp-Session-Id` header), so concurrent clients are isolated from each other even though they share the process. It binds to `localhost` by default (FastMCP's default host), so the server is not exposed to the network unless deliberately reconfigured.

```js
// dist/index.js (after) — abridged
const transportEnv = (process.env.GOOGLE_MCP_TRANSPORT || 'stdio').toLowerCase();
const useHttp = transportEnv === 'http' || transportEnv === 'httpstream';
const httpPort = Number(process.env.GOOGLE_MCP_PORT) || 3939;
const httpEndpoint = process.env.GOOGLE_MCP_ENDPOINT || '/mcp';

// ...

if (useHttp) {
    await server.start({
        transportType: 'httpStream',
        httpStream: { port: httpPort, endpoint: httpEndpoint },
    });
} else {
    await server.start({ transportType: 'stdio' });
}
```

## The non-obvious bug this had to avoid

The server installs stdio shutdown handlers so it exits when its client disconnects (this is the existing fix for orphaned processes on Windows, where SIGTERM isn't reliably delivered to a child when the parent dies):

```js
process.stdin.on('close', () => process.exit(0));
process.stdin.on('end',   () => process.exit(0));
```

In **HTTP mode the server is a detached daemon** — it has no stdio client, so its stdin reaches `end`/`close` almost immediately at launch. Left as-is, those handlers would make the HTTP server **exit the instant it started.**

Fix: these handlers are now gated to stdio mode only.

```js
if (!useHttp) {
    process.stdin.on('close', () => { /* shut down */ process.exit(0); });
    process.stdin.on('end',   () => { /* shut down */ process.exit(0); });
}
```

`SIGINT`/`SIGTERM` handlers remain active in both modes for clean shutdown of the daemon.

## How to use it

**1. Start one shared server** and keep it running (login item / service / `pm2` — your choice of process manager):

```bash
GOOGLE_MCP_TRANSPORT=http GOOGLE_MCP_PORT=3939 google-tools-mcp
```

**2. Point each client at the URL** instead of a spawn command:

```json
{
  "mcpServers": {
    "google": { "type": "http", "url": "http://localhost:3939/mcp" }
  }
}
```

Every client now connects to the same process. Auth (`google-tools-mcp auth` / `setup`) is unchanged and still runs over stdio as a one-off.

## Operational notes / trade-offs (important for adopters)

- **Lifecycle is now yours to manage.** A stdio server lives and dies with its client. The shared HTTP server does **not** — it won't auto-start when a client connects, and won't auto-stop when they all disconnect. You run it as a long-lived process (e.g. a Windows Scheduled Task at logon, a launchd/systemd unit, or `pm2 start`).
- **Shared auth + shared process.** All clients use the one server's OAuth/token state and its single Node event loop. FastMCP isolates *sessions*, but they're all served by one process, so a crash or token expiry affects everyone connected.
- **Keep it local.** Binds to `localhost` by default. Don't expose the port to the network; anyone who can reach it can use your authenticated Google session. (FastMCP honors `FASTMCP_HOST` if you ever need a different bind, but the default is safe.)
- **Default path unchanged.** Without `GOOGLE_MCP_TRANSPORT=http`, this is byte-for-byte the same runtime behavior as before.

## Testing performed

- Started the server with `GOOGLE_MCP_TRANSPORT=http` and confirmed it **stays alive** (does not die on the immediate stdin-end — verifies the gating fix).
- `GET /health` → `200`; FastMCP logged `server is running on HTTP Stream at http://localhost:PORT/mcp`.
- Confirmed default (no env var) still starts in stdio mode and logs the stdio startup path.
- All 11 tool categories load at startup in both modes.

## Files changed

- `dist/index.js` — env-driven transport selection + stdin-handler gating. (Edited in `dist/` because the repo is dist-only; see #35.)
- `README.md` — new "Shared HTTP mode" section + three env-var table rows.

## Compatibility

- No new dependencies.
- No change to tool surface, auth, or config format.
- Default transport unchanged (`stdio`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added environment variables documentation for HTTP-based server operation
  * Introduced shared HTTP mode enabling a single server instance to serve multiple clients
  * Included configuration examples and setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->